### PR TITLE
Create code-of-conduct.md

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,40 @@
+# Code of Conduct
+## Version 1.0 – November 18, 2019
+
+Our community is our best asset and we believe that diversity gives strength. We are building a welcoming and diverse community of software users and developers from a range of research domains. Whether you’re a regular contributor or a
+newcomer, we care about making this a safe place for you. We are committed to providing a safe, inclusive, welcoming, and harassment-free experience for everyone. We try to cultivate a community with shared values, where people are
+comfortable exploring ideas, asking questions, and saying things like “I don’t understand” or “Why”. Assume competence in the people you interact with. There are no stupid questions. Be considerate in speech and actions, and actively seek
+to acknowledge and respect the boundaries of fellow community members. Take care of each other. Alert a member of the Organising Committee if you notice a dangerous situation, someone in distress, or a potential violation of this
+Code of Conduct, even if it seems inconsequential. We do not tolerate harassment in any form. Refrain from demeaning, discriminatory, or harassing behavior and speech. Harassment includes, but is not limited to:
+* offensive comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices
+* unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, or employment
+* sustained or willful disruption of discussions, talks, or other events
+* deliberate intimidation
+* continued one-on-one communication after requests to cease
+* unwanted photography or recording, including logging online activity for harassment purposes
+* pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others
+* inappropriate physical contact without consent or after a request to stop
+* stalking or following
+* threats of violence or incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm
+* use of sexual or discriminatory imagery, comments, or jokes
+* unwelcome sexual attention
+* deliberate ‘outing’ of any aspect of a person’s identity without their consent except as necessary to protect vulnerable people from intentional abuse
+* deliberate misgendering or use of ‘dead’ or rejected names
+* publication of non-harassing private communication
+
+We prioritize marginalized people’s safety over privileged people’s comfort. We will not act on complaints regarding:
+* ‘reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’
+* reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you”
+* communicating in a ‘tone’ you don’t find congenial
+* criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions
+
+If anyone engages in harassing behavior, the Committee will take action that may include warning the offender or asking them to leave an event or an online channel either temporarily or permanently, or seeking help from law enforcement. This Code of Conduct applies to all people participating in this community. It applies to all modes of interaction online including GitHub project repositories, emails, Slack, and in person at meetings and events officially endorsed by the group, including social gatherings affiliated with the event.
+
+Reporting Guidelines
+If you experience or witness unacceptable behavior, or have any other concerns, please submit a report to the Committee as soon as possible using this form. Alternatively, you may email a member of the Committee. You may also make a report directly to one member of the Committee by contacting them directly. If any member of the Committee has a conflict of interest with a report, they will be recused and will not have access to the content or process of the report followup. At an in-person event, please reach out to anyone named as a member of that event-specific Code of Conduct Committee, or to venue staff or security who will be present throughout the event. If you are planning to attend an upcoming event or join an online channel, and have concerns regarding another individual who may be present, please submit a report as described above. We will work with you to take precautions to ensure your comfort and safety. These precautions may include: providing an escort, preparing onsite event staff, and/or providing on-site contact mobile phone numbers for immediate contact. In some cases, we may take action to prevent a harasser from attending an event. The Code of Conduct Committee will investigate and decide responses to reports with the aim of making a decision and implementing enforcement as soon as is reasonably possible. We thank you for working with us to make this group a safe, enjoyable, friendly and enriching experience for everyone who participates.
+
+### License and Credits
+
+This Code of Conduct has been adapted from the rOpenSci Code of Conduct. To the extent possible under law, rOpenSci has waived all copyright and related or neighboring rights to their rOpenSci Code of Conduct, and we do the same with this modified version which we release into the public domain.
+
+https://ropensci.org/code-of-conduct/


### PR DESCRIPTION
Initial version of Code of Conduct, based on the rOpenSci Code of Conduct #2 